### PR TITLE
Fix clear session

### DIFF
--- a/src/lib/containers/IssueCredentials/IssueCredentials.js
+++ b/src/lib/containers/IssueCredentials/IssueCredentials.js
@@ -19,7 +19,8 @@ class IssueCredentials extends Component {
   componentDidMount() {
     // TODO: this can be refactored out of here if
     // it becomes something like startOrResumeDivaSession(viewId)
-    if (!this.props.divaSession || this.props.divaSession.sessionStatus === 'ABANDONED') {
+    // TODO: check properly for divaSession
+    if (!this.props.divaSession || Object.keys(this.props.divaSession).length === 0 || this.props.divaSession.sessionStatus === 'ABANDONED') {
       this.startIrmaSession();
     }
   }

--- a/src/lib/containers/RequestAttributeDisclosure/RequestAttributeDisclosure.js
+++ b/src/lib/containers/RequestAttributeDisclosure/RequestAttributeDisclosure.js
@@ -19,7 +19,8 @@ class RequestAttributeDisclosure extends Component {
   componentDidMount() {
     // TODO: this can be refactored out of here if
     // it becomes something like startOrResumeDivaSession(viewId)
-    if (!this.props.divaSession || this.props.divaSession.sessionStatus === 'ABANDONED') {
+    // TODO: check properly for divaSession
+    if (!this.props.divaSession || Object.keys(this.props.divaSession).length === 0 || this.props.divaSession.sessionStatus === 'ABANDONED') {
       this.startIrmaSession();
     }
   }

--- a/src/lib/containers/Sign/Sign.js
+++ b/src/lib/containers/Sign/Sign.js
@@ -19,7 +19,8 @@ class Sign extends Component {
   componentDidMount() {
     // TODO: this can be refactored out of here if
     // it becomes something like startOrResumeDivaSession(viewId)
-    if (!this.props.divaSession || this.props.divaSession.sessionStatus === 'ABANDONED') {
+    // TODO: check properly for divaSession
+    if (!this.props.divaSession || Object.keys(this.props.divaSession).length === 0 || this.props.divaSession.sessionStatus === 'ABANDONED') {
       this.startIrmaSession();
     }
   }

--- a/src/lib/reducers/diva-reducer.js
+++ b/src/lib/reducers/diva-reducer.js
@@ -86,9 +86,15 @@ export default (state = initialState, action) => {
         sessionStatus: 'POLLING_FAILED',
       });
     case types.STOP_POLLING:
-      return updateStateForViewIdWith(state, action.viewId, {
-        isPolling: false,
-      });
+      return {
+        ...state,
+        sessions: {
+          ...state.sessions,
+          [action.viewId]: {
+            isPolling: false,
+          },
+        },
+      };
     case types.SESSION_COMPLETED:
       return updateStateForViewIdWith(state, action.viewId, {
         proofStatus: action.proofStatus,

--- a/src/lib/reducers/diva-reducer.js
+++ b/src/lib/reducers/diva-reducer.js
@@ -57,7 +57,6 @@ export default (state = initialState, action) => {
           ...state.sessions,
           [action.viewId]: {
             irmaSessionType: action.irmaSessionType,
-            isPolling: false,
             sessionStatus: 'REQUESTED',
             started: true,
           },
@@ -73,10 +72,6 @@ export default (state = initialState, action) => {
       return updateStateForViewIdWith(state, action.viewId, {
         sessionStatus: 'FAILED_TO_START',
       });
-    case types.START_POLLING:
-      return updateStateForViewIdWith(state, action.viewId, {
-        isPolling: true,
-      });
     case types.PROCESS_POLL_SUCCESS:
       return updateStateForViewIdWith(state, action.viewId, {
         sessionStatus: action.data.serverStatus,
@@ -90,9 +85,7 @@ export default (state = initialState, action) => {
         ...state,
         sessions: {
           ...state.sessions,
-          [action.viewId]: {
-            isPolling: false,
-          },
+          [action.viewId]: {},
         },
       };
     case types.SESSION_COMPLETED:


### PR DESCRIPTION
This PR will fix a bug that lets the frontend 'hang' in 'Disclosure successful' state when the entire browser session is cleared (the clearSession action).

This is fixed by clearing up the entire divaSession after we stop polling. Because in this way, divaSession won't longer always exist, we also needed to fix the three views by checking on existence of divaSession before checking divaSession.sessionStatus.

I also removed the 'isPoling' state from the reducer, since that variable is never used anywhere?

I'm still not completely convinced that my fixes will cover all the edge cases, by not introducing new bugs. So please think about it, check and test carefully before merging this PR.